### PR TITLE
add ca-certificates package in release container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update \
 FROM debian:${DEBIAN_VERSION}-slim
 
 RUN apt update \
-    && apt install -y curl libssl1.1
+    && apt install -y curl libssl1.1 ca-certificates
 
 COPY --from=build /tmp/usr/sbin/3cxsbc /usr/sbin/3cxsbc
 


### PR DESCRIPTION
I've added the ca-certificates package to the docker container. This package includes CA certificates for all CAs trusted by debian. For example the LetsEncrypt CA which is default used by 3cx was not included in the original docker. Without the CA certificate the first curl command fails and the docker can't start.